### PR TITLE
To fix download error package code.google.com/p/getopt: exec: "hg": e…

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	getopt "code.google.com/p/getopt"
+	getopt "github.com/pborman/getopt"
 )
 
 var exclude = getopt.ListLong("exclude", 'x', "", "glob patterns to exclude")


### PR DESCRIPTION
…xecutable file not found in %PATH%

Error message:

> go get code.google.com/p/getopt
> go: missing Mercurial command. See http://golang.org/s/gogetcmd
> package code.google.com/p/getopt: exec: "hg": executable file not found in %PATH%

On code.google.com/p/getopt said that they moved to github.com/pborman/getopt.

I changed that and everything is fine now for me
