### PR TITLE
error output to stdout is corrupting output on normal case

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,9 +97,6 @@ func main() {
 		contentType := ""
 		for firstTime := true; firstTime || bytesRead == len(fileBytes); {
 		    bytesRead, err = file.Read(fileBytes)
-		    if err != nil {
-			fmt.Printf("%s\n", err);
-		    }
 		    if (firstTime) {
 			contentType = http.DetectContentType(fileBytes)
 			firstTime = false

--- a/main.go
+++ b/main.go
@@ -7,7 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-       "net/http"
+	"net/http"
+	"io"
 
 	getopt "github.com/pborman/getopt"
 )
@@ -97,6 +98,14 @@ func main() {
 		contentType := ""
 		for firstTime := true; firstTime || bytesRead == len(fileBytes); {
 		    bytesRead, err = file.Read(fileBytes)
+		    // If we got back and error and it isn't the end of file then
+		    // skip it.  This does "something" with 0 length files.  It is
+		    // likely we should really be categorizing those based on file
+		    // extension.
+		    if err != nil && err != io.EOF {
+			fmt.Fprintf(os.Stderr, "Error reading %s: %s\n", path, err);
+			return nil
+		    }
 		    if (firstTime) {
 			contentType = http.DetectContentType(fileBytes)
 			firstTime = false


### PR DESCRIPTION
It is possible for a Read to return 0, io.EOF in normal cases.
