### PR TITLE
DetectContentType fails on SVG

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,13 @@ func main() {
 			fmt.Printf("%s\n", err);
 		    }
 		    if (firstTime) {
-			contentType = http.DetectContentType(fileBytes)
+			if strings.HasSuffix(relPath, ".svg") {
+			    // If we start to need a set of overrides for DetectContentType
+			    // then we need to find a different way to do this.
+			    contentType = "image/svg+xml"
+			} else {
+			    contentType = http.DetectContentType(fileBytes)
+			}
 			firstTime = false
 		    }
 		    hasher.Write(fileBytes)


### PR DESCRIPTION
Provide an override based on extension.  If we find many such overrides
then we probably need to either formalize that and expose it via the
command line or replace DetectContentType with something better.
