### PR TITLE
Added support for css content type

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,6 +106,10 @@ func main() {
 			// If we start to need a set of overrides for DetectContentType
 			// then we need to find a different way to do this.
 			contentType = "image/svg+xml"
+		} else if strings.HasSuffix(relPath, ".css") {
+			// If we start to need a set of overrides for DetectContentType
+			// then we need to find a different way to do this.
+			contentType = "text/css"
 		} else {
 			contentType = http.DetectContentType(fileBytes)
 		}


### PR DESCRIPTION
Browser was complaining that css files were being passed from server with content-type of text/plain.

This fixes it so that they have the correct content-type which means the website will render correctly.