### PR TITLE
Encode module into source paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,11 +120,13 @@ func main() {
 		hasher.Write([]byte(relPath))
 		resourceName := fmt.Sprintf("%x", hasher.Sum(nil))
 
+		modulePath := fmt.Sprintf("${path.module}/%s", path)
+
 		resourcesMap[resourceName] = map[string]interface{}{
 			"bucket":       bucketName,
 			"key":          relPath,
-			"source":       path,
-			"etag":         fmt.Sprintf("${md5(file(%q))}", path),
+			"source":       modulePath,
+			"etag":         fmt.Sprintf("${md5(file(%q))}", modulePath),
 			"content_type": contentType,
 		}
 

--- a/main.go
+++ b/main.go
@@ -128,6 +128,9 @@ func main() {
 			"source":       modulePath,
 			"etag":         fmt.Sprintf("${md5(file(%q))}", modulePath),
 			"content_type": contentType,
+			"lifecycle": map[string][1]string{
+				"ignore_changes": {"source"},
+			},
 		}
 
 		return nil


### PR DESCRIPTION
This means a website can work as a module,

e.g. when you have a static site as your fallback page