### PR TITLE
Add hcl support in output

### DIFF
--- a/hcl.go
+++ b/hcl.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/printer"
+	"github.com/hashicorp/hcl/hcl/token"
+)
+
+type Hcl struct {
+	Resources []*ast.ObjectItem
+}
+
+type Resource struct {
+	Item *ast.ObjectItem
+}
+
+func (h *Hcl) Encode(input map[string]interface{}) {
+
+	resources, ok := input["resource"]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Hcl: Key resource not found in input data.")
+		return
+	}
+
+	for name, resource := range resources.(map[string]interface{}) {
+		for resourcekey, attributes := range resource.(map[string]interface{}) {
+			res := NewResource(name, resourcekey)
+			for attrname, attrvalue := range attributes.(map[string]interface{}) {
+				res.AddAttribute(attrname, attrvalue.(string))
+			}
+			h.AddResource(res)
+		}
+	}
+
+	root := &ast.File{
+		Node: &ast.ObjectList{
+			Items: h.Resources,
+		}}
+	printer.Fprint(os.Stdout, root)
+}
+
+func (h *Hcl) AddResource(r *Resource) {
+	h.Resources = append(h.Resources, r.Item)
+}
+
+//AddResource build resource AST node
+func NewResource(name, key string) *Resource {
+	resource := &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Pos: token.Pos{Filename: "", Line: 1}, Text: "resource", JSON: false},
+			},
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.STRING, Pos: token.Pos{Filename: "", Line: 1}, Text: fmt.Sprintf("\"%s\"", name), JSON: false},
+			},
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.STRING, Pos: token.Pos{Filename: "", Line: 1}, Text: fmt.Sprintf("\"%s\"", key), JSON: false},
+			},
+		},
+		Val: &ast.ObjectType{
+			List: &ast.ObjectList{
+				Items: []*ast.ObjectItem{},
+			},
+		},
+	}
+	return &Resource{Item: resource}
+}
+
+//AddResource add configuration argument to resource
+func (r *Resource) AddAttribute(name, value string) *Resource {
+	line := len(r.Item.Val.(*ast.ObjectType).List.Items) + 1
+	r.Item.Val.(*ast.ObjectType).List.Items = append(r.Item.Val.(*ast.ObjectType).List.Items,
+		&ast.ObjectItem{
+			Keys: []*ast.ObjectKey{
+				&ast.ObjectKey{Token: token.Token{Type: token.IDENT, Pos: token.Pos{Line: line}, Text: name, JSON: false}},
+			},
+			Assign: token.Pos{Filename: "", Line: line},
+			Val: &ast.LiteralType{
+				Token: token.Token{Type: token.STRING, Pos: token.Pos{Filename: "", Line: line}, Text: fmt.Sprintf("\"%s\"", value), JSON: false}},
+		},
+	)
+	return r
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 )
 
 var exclude = getopt.ListLong("exclude", 'x', "", "glob patterns to exclude")
+var hcloutput = getopt.Bool('t', "print output in hcl")
 var help = getopt.BoolLong("help", 'h', "", "print this help")
 
 func main() {
@@ -131,6 +132,11 @@ func main() {
 		return nil
 	})
 
+	if *hcloutput {
+		hcl := Hcl{}
+		hcl.Encode(result)
+		return
+	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.Encode(result)
 }


### PR DESCRIPTION
This solves #5.

Added new ```-t``` command line argument to print resources in hcl.

```
# dist/darwin/terraform-s3-dir -t   /tmp/hcl/  example

resource "aws_s3_bucket_object" "62cdb7020ff920e5aa642c3d4066950dd1f01f4d" {
  bucket       = "example"
  key          = "bar"
  source       = "/private/tmp/hcl/bar"
  etag         = "${md5(file("/private/tmp/hcl/bar"))}"
  content_type = "application/octet-stream"
}

resource "aws_s3_bucket_object" "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" {
  bucket       = "example"
  key          = "foo"
  source       = "/private/tmp/hcl/foo"
  etag         = "${md5(file("/private/tmp/hcl/foo"))}"
  content_type = "application/octet-stream"
}
```